### PR TITLE
returning Container() if icon is null

### DIFF
--- a/lib/components/stats/stats_card.dart
+++ b/lib/components/stats/stats_card.dart
@@ -123,7 +123,7 @@ class StatsCard extends StatelessWidget {
       children: [
         Row(
           children: <Widget>[
-            icon,
+            icon == null ? Container() : icon,
             Text(
               (int.parse(count) > 0) ? '+$count' : '$count',
               style: TextStyle(


### PR DESCRIPTION
Fix for the exception causing the StatsCard(s) to go blank